### PR TITLE
Enable CSV import and Radicale syncing in Flask UI

### DIFF
--- a/Templates/base.html
+++ b/Templates/base.html
@@ -8,11 +8,9 @@
     <body>
         <h1>CDAV Admin</h1>
         <nav>
-            <a href="/">Home</a>
-            <a>Import</a>
-            <a>Export</a>
-            <a>Users</a>
-            <a>Contacts</a>
+            <a href="{{ url_for('index') }}">Home</a>
+            <a href="{{ url_for('import_csv') }}">Import</a>
+            <a href="{{ url_for('export_group') }}">Export</a>
         </nav>
         <hr>
         {% with messages = get_flashed_messages() %}

--- a/Templates/export.html
+++ b/Templates/export.html
@@ -8,4 +8,4 @@
   <input type="text" name="addressbook"><br><br>
   <button type="submit">Export</button>
 </form>
-{% end block %}
+{% endblock %}

--- a/Templates/import.html
+++ b/Templates/import.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% blockcontent %}
+{% block content %}
 <h2>Import Contacts</h2>
 <form method="POST" enctype="multipart/form-data">
     <label for="file">CSV File:</label><br>

--- a/app.py
+++ b/app.py
@@ -1,9 +1,14 @@
 #jfr
-import requests
-from flask import Flask, render_template, request, redirect, url_for
-import PythonScripts
+import os
+from flask import Flask, render_template, request, redirect, url_for, flash
+
+from PythonScripts.psql_im import import_users_from_csv
+from PythonScripts.radicale_ex import upload_group_to_radicale
+from PythonScripts.radicale_sync import sync_contacts
+from PythonScripts.utils import RAD
 
 app = Flask(__name__)
+app.secret_key = os.getenv("SECRET_KEY", "dev")
 
 #Needed pages: Index, Import, Export, View (for contacts and users)
 #Import page needs: Importing from file (take filepath as upload)
@@ -16,22 +21,36 @@ def index():
 
 @app.route('/import', methods=["GET", "POST"])
 def import_csv():
-    if request.method == 'POST':
-        file = request.files["file"]
-        group = request.form["group"]
-        filepath = f"/tmp/{file.filename}"
-        file.save(filepath)
+    """Upload a CSV of users and push them to Radicale."""
+    if request.method == "POST":
+        uploaded = request.files["file"]
+        group = request.form.get("group", "")
+        filepath = os.path.join("/tmp", uploaded.filename)
+        uploaded.save(filepath)
+
+        # Import into the database
         import_users_from_csv(filepath, group)
-        flash("Contacts imported successfully")
-        return redirect("/")
-    return render_template('import.html')
 
-@app.route('/export', methods=["POST"])
+        # Push to the admin addressbook and sync to JAMF
+        upload_group_to_radicale(group, RAD["addressbook"])
+        sync_contacts()
+
+        flash("Contacts imported and synced successfully")
+        return redirect(url_for("index"))
+
+    return render_template("import.html")
+
+@app.route('/export', methods=["GET", "POST"])
 def export_group():
-    group = request.form["group"]
-    addressbook = request.form["addressbook"]
-    upload_group_to_radicale(group, addressbook)
+    if request.method == "POST":
+        group = request.form["group"]
+        addressbook = request.form["addressbook"]
+        upload_group_to_radicale(group, addressbook)
+        flash("Group exported to Radicale")
+        return redirect(url_for("index"))
+
+    return render_template("export.html")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- connect frontend to existing Python scripts
- allow CSV upload of users, push contacts to Radicale and sync to JAMF
- expose export functionality
- fix template links and blocks

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687fda618a4883279f88306bc1dab436